### PR TITLE
[IMP] mail_composer_cc_bcc: filter out partner with no email address and set "" for partner with no name

### DIFF
--- a/mail_composer_cc_bcc/models/mail_mail.py
+++ b/mail_composer_cc_bcc/models/mail_mail.py
@@ -14,9 +14,7 @@ _logger = logging.getLogger(__name__)
 
 
 def format_emails(partners):
-    emails = [
-        tools.formataddr((p.name or "False", p.email or "False")) for p in partners
-    ]
+    emails = [tools.formataddr((p.name, p.email)) for p in partners if p.email]
     return ", ".join(emails)
 
 


### PR DESCRIPTION
- Filtered out partner without email address
- Use "" instead of "False" for the partner's name